### PR TITLE
feat(smartd-sysmon): add smart descriptions for Sysmon events (2 6 8 9 11 12 17 18)

### DIFF
--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -930,6 +930,58 @@
           "value": 12
         },
         {
+          "field": "action.properties.MessEventType",
+          "value": "CreateKey"
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Registry value of the key {action.properties.TargetObject} created by {process.executable} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 12
+        },
+        {
+          "field": "action.properties.MessEventType",
+          "value": "CreateValue"
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Registry key {action.properties.TargetObject} deleted by {process.executable} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 12
+        },
+        {
+          "field": "action.properties.MessEventType",
+          "value": "DeleteKey"
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Registry value of the key {action.properties.TargetObject} deleted by {process.executable} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 12
+        },
+        {
+          "field": "action.properties.MessEventType",
+          "value": "DeleteValue"
+        },
+        {
           "field": "event.provider",
           "value": "Microsoft-Windows-Sysmon"
         }

--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -900,7 +900,7 @@
       ]
     },
     {
-      "value": "Process {process.executable} read on {action.properties.Device} device on {log.hostname} hostname",
+      "value": "Process {process.executable} read on {action.properties.Device} device on {log.hostname}",
       "conditions": [{
           "field": "action.id",
           "value": 9

--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -936,7 +936,7 @@
       ]
     },
     {
-      "value": "File {file.name} created by {process.executable}device on {log.hostname}",
+      "value": "File {file.name} created by {process.executable} on {log.hostname}",
       "conditions": [{
           "field": "action.id",
           "value": 11

--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -940,7 +940,7 @@
       ]
     },
     {
-      "value": "Registry value of the key {action.properties.TargetObject} created by {process.executable} on {log.hostname}",
+      "value": "Registry value {action.properties.TargetObject} created by {process.executable} on {log.hostname}",
       "conditions": [{
           "field": "action.id",
           "value": 12

--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -972,7 +972,7 @@
       ]
     },
     {
-      "value": "Registry value of the key {action.properties.TargetObject} deleted by {process.executable} on {log.hostname}",
+      "value": "Registry value {action.properties.TargetObject} deleted by {process.executable} on {log.hostname}",
       "conditions": [{
           "field": "action.id",
           "value": 12

--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -887,7 +887,102 @@
         }
       ]
     },
-
+    {
+      "value": "Process {process.executable} changed the creation time of the file {file.name} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 2
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Driver {process.executable} loaded on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 6
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Process {action.properties.SourceImage} created a thread in process {action.properties.TargetImage} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 8
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Process {process.executable} read on {action.properties.Device} device on {log.hostname} hostname",
+      "conditions": [{
+          "field": "action.id",
+          "value": 9
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "File {file.name} created by {process.executable}device on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 11
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Registry key {action.properties.TargetObject} created by {process.executable} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 12
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Pipe {action.properties.PipeName} created by {process.executable} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 17
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "Pipe {action.properties.PipeName} connected by {process.executable} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 18
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
 
     {
       "value": "Microsoft Defender Antivirus client is up and running in a healthy state on {log.hostname}",

--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -852,7 +852,7 @@
       ]
     },
     {
-      "value": "Network connection from {source.ip} to {destination.ip} on port {destination.port} by {process.executable}",
+      "value": "Network connection from {source.ip} to {destination.ip}:{destination.port} by {process.executable} on {log.hostname}",
       "conditions": [{
           "field": "action.id",
           "value": 3

--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -828,18 +828,6 @@
 
 
     {
-      "value": "{log.hostname} performed a DNS query for name {dns.question.name} (status: {dns.response_code})",
-      "conditions": [{
-          "field": "action.id",
-          "value": 22
-        },
-        {
-          "field": "event.provider",
-          "value": "Microsoft-Windows-Sysmon"
-        }
-      ]
-    },
-    {
       "value": "Process {process.executable} created by {user.name} on {log.hostname}",
       "conditions": [{
           "field": "action.id",
@@ -852,10 +840,10 @@
       ]
     },
     {
-      "value": "Registry key {action.properties.TargetObject} set by {process.executable} on {log.hostname}",
+      "value": "Process {process.executable} changed the creation time of the file {file.name} on {log.hostname}",
       "conditions": [{
           "field": "action.id",
-          "value": 13
+          "value": 2
         },
         {
           "field": "event.provider",
@@ -880,18 +868,6 @@
       "conditions": [{
           "field": "action.id",
           "value": 5
-        },
-        {
-          "field": "event.provider",
-          "value": "Microsoft-Windows-Sysmon"
-        }
-      ]
-    },
-    {
-      "value": "Process {process.executable} changed the creation time of the file {file.name} on {log.hostname}",
-      "conditions": [{
-          "field": "action.id",
-          "value": 2
         },
         {
           "field": "event.provider",
@@ -960,6 +936,18 @@
       ]
     },
     {
+      "value": "Registry key {action.properties.TargetObject} set by {process.executable} on {log.hostname}",
+      "conditions": [{
+          "field": "action.id",
+          "value": 13
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
       "value": "Pipe {action.properties.PipeName} created by {process.executable} on {log.hostname}",
       "conditions": [{
           "field": "action.id",
@@ -976,6 +964,18 @@
       "conditions": [{
           "field": "action.id",
           "value": 18
+        },
+        {
+          "field": "event.provider",
+          "value": "Microsoft-Windows-Sysmon"
+        }
+      ]
+    },
+    {
+      "value": "{log.hostname} performed a DNS query for name {dns.question.name} (status: {dns.response_code})",
+      "conditions": [{
+          "field": "action.id",
+          "value": 22
         },
         {
           "field": "event.provider",


### PR DESCRIPTION
I added smart descriptions for the most common Sysmon events (not yet done):
* 2: A process changed a file creation time
* 6: Driver loaded
* 8: CreateRemoteThread
* 9: RawAccessRead
* 11: FileCreate
* 12: RegistryEvent (Object create and delete)
* 17: PipeEvent (Pipe Created)
* 18: PipeEvent (Pipe Connected)

Both ECS fields `action.properties.Device` and `action.properties.PipeName` should be added in the detail of the events so that their value is displayed.