### PR TITLE
feat(smartdescriptions): sentinelone default

### DIFF
--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -1,4 +1,8 @@
 {
+  "sentinelone": [{
+    "value": "{sentinelone.primaryDescription}",
+    "conditions": []
+  }],
   "fortiweb": [{
     "conditions": [{
       "field": "event.kind",


### PR DESCRIPTION
Not very smart, but provides a much better experience than displaying the event's JSON.