### PR TITLE
[FIX] url.domain+url.path replaced by url.orignal in smartDescription

### DIFF
--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -944,7 +944,7 @@
       }]
     },
     {
-      "value": "{source.ip} connected to {url.domain}{url.path} on {customer.zone_name} (category {application.category})",
+      "value": "{source.ip} connected to {url.original}:{destination.port} on {customer.zone_name} (category {application.category})",
       "conditions": [{
           "field": "event.dataset",
           "value": "fortinet.webfilter"


### PR DESCRIPTION
For faster investigations, it is important to have the full url in the timeline.

We also add the port in order to detect more quickly the use of an unusual port.