### PR TITLE
feat/add a playbook rejecting old alerts (last update > 1 year)

### DIFF
--- a/playbooks/templates/Reject_old_alerts.json
+++ b/playbooks/templates/Reject_old_alerts.json
@@ -1,0 +1,69 @@
+{
+  "name": "Reject old alerts (1 year)",
+  "uuid": "70120faa-7e8e-4977-99c5-9b9e4ad02d4f",
+  "nodes": {
+    "0": {
+      "name": "cron",
+      "type": "trigger",
+      "outputs": {
+        "default": [
+          "1"
+        ]
+      },
+      "module_uuid": "1ad1b7ce-e335-4532-83ce-1d43c864720c",
+      "trigger_uuid": "5039c9fe-b2d8-40b3-a11b-d2a810ddbf91"
+    },
+    "1": {
+      "icon": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTcwIiBoZWlnaHQ9IjE3MCIgdmlld0JveD0iMCAwIDE3MCAxNzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0zNy4zNjU3IDU3LjgwMzlIMjcuNzE1MVYxMTMuNjg2SDM3LjM2NTdWNTcuODAzOVoiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGQ9Ik05LjY1MDY2IDM3LjY4NjNINTYuNDE5Mkg2Ni4wNjk5SDE2MC4xMDJWMTMyLjA2NUg2Ni4wNjk5SDU2LjQxOTJIOS42NTA2NlYzNy42ODYzWk0wIDE0MkgxNzBWMjhIMFYxNDJaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMTEzLjMzNCA1Ny44MDM5QzEyOC42NzYgNTcuODAzOSAxNDEuMDQ4IDcwLjIyMjIgMTQxLjA0OCA4NS42MjA5QzE0MS4wNDggMTAxLjAyIDEyOC42NzYgMTEzLjQzOCAxMTMuMzM0IDExMy40MzhDOTcuOTkxNiAxMTMuNDM4IDg1LjYxOSAxMDEuMDIgODUuNjE5IDg1LjYyMDlDODUuNjE5IDcwLjIyMjIgOTcuOTkxNiA1Ny44MDM5IDExMy4zMzQgNTcuODAzOVpNMTEzLjMzNCAxMjMuMzczQzEzNC4xMiAxMjMuMzczIDE1MC45NDYgMTA2LjQ4NCAxNTAuOTQ2IDg1LjYyMDlDMTUwLjk0NiA2NC43NTgxIDEzNC4xMiA0OC4xMTc2IDExMy4zMzQgNDguMTE3NkM5Mi41NDc2IDQ4LjExNzYgNzUuNzIwOSA2NS4wMDY1IDc1LjcyMDkgODUuODY5MkM3NS43MjA5IDEwNi43MzIgOTIuNTQ3NiAxMjMuMzczIDExMy4zMzQgMTIzLjM3M1oiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=",
+      "name": "list old alerts",
+      "type": "action",
+      "outputs": {
+        "default": [
+          "2"
+        ]
+      },
+      "arguments": {
+        "sort": "updated_at",
+        "stix": false,
+        "limit": 100,
+        "offset": 0,
+        "visible": true,
+        "direction": "desc",
+        "with_count": false,
+        "date[updated_at]": "{{(-63244800) | time_with_delta }},{{(-31622400) | time_with_delta}}",
+        "match[status_uuid]": "2efc4930-1442-4abb-acf2-58ba219a4fd0"
+      },
+      "action_uuid": "050b7bc1-4df8-47bc-84e2-ec265821e18a",
+      "module_uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a"
+    },
+    "2": {
+      "loop": [
+        "9"
+      ],
+      "name": "Foreach",
+      "type": "operator",
+      "items": "{{ node.1['items'] }}",
+      "outputs": {
+        "default": []
+      },
+      "subtype": "foreach"
+    },
+    "9": {
+      "icon": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTcwIiBoZWlnaHQ9IjE3MCIgdmlld0JveD0iMCAwIDE3MCAxNzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0zNy4zNjU3IDU3LjgwMzlIMjcuNzE1MVYxMTMuNjg2SDM3LjM2NTdWNTcuODAzOVoiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGQ9Ik05LjY1MDY2IDM3LjY4NjNINTYuNDE5Mkg2Ni4wNjk5SDE2MC4xMDJWMTMyLjA2NUg2Ni4wNjk5SDU2LjQxOTJIOS42NTA2NlYzNy42ODYzWk0wIDE0MkgxNzBWMjhIMFYxNDJaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMTEzLjMzNCA1Ny44MDM5QzEyOC42NzYgNTcuODAzOSAxNDEuMDQ4IDcwLjIyMjIgMTQxLjA0OCA4NS42MjA5QzE0MS4wNDggMTAxLjAyIDEyOC42NzYgMTEzLjQzOCAxMTMuMzM0IDExMy40MzhDOTcuOTkxNiAxMTMuNDM4IDg1LjYxOSAxMDEuMDIgODUuNjE5IDg1LjYyMDlDODUuNjE5IDcwLjIyMjIgOTcuOTkxNiA1Ny44MDM5IDExMy4zMzQgNTcuODAzOVpNMTEzLjMzNCAxMjMuMzczQzEzNC4xMiAxMjMuMzczIDE1MC45NDYgMTA2LjQ4NCAxNTAuOTQ2IDg1LjYyMDlDMTUwLjk0NiA2NC43NTgxIDEzNC4xMiA0OC4xMTc2IDExMy4zMzQgNDguMTE3NkM5Mi41NDc2IDQ4LjExNzYgNzUuNzIwOSA2NS4wMDY1IDc1LjcyMDkgODUuODY5MkM3NS43MjA5IDEwNi43MzIgOTIuNTQ3NiAxMjMuMzczIDExMy4zMzQgMTIzLjM3M1oiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=",
+      "name": "Reject alerts",
+      "type": "action",
+      "outputs": {
+        "default": []
+      },
+      "arguments": {
+        "uuid": "{{ node.2.default.value.uuid }}",
+        "comment": "Alert rejected due to inactivity.",
+        "action_uuid": "ade85d7b-7507-4026-bfc6-cc006d10ddac"
+      },
+      "action_uuid": "c4b84449-a26f-4f18-bde4-33efa921f4d4",
+      "module_uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a"
+    }
+  },
+  "workspace": "Operation Center",
+  "description": "Reject old alerts not updated for 1 year."
+}

--- a/playbooks/templates/playbooks.json
+++ b/playbooks/templates/playbooks.json
@@ -50,5 +50,13 @@
         "tags": [
             "alert"
         ]
+    },
+    {
+        "file": "Reject_old_alerts.json",
+        "name": "Reject old alerts (1 year)",
+        "description": "Reject old alerts not updated for 1 year.",
+        "tags": [
+            "alert"
+        ]
     }
 ]


### PR DESCRIPTION
New playbook design to automatically close alerts with no update in more than a year.
Supplements PR #49 