### PR TITLE
feat(stormshield): Add smart description for log action

### DIFF
--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -32,6 +32,22 @@
           "type": "was denied a connection to"
         }
       ]
+    },
+    {
+      "value": "Connection logged by rule {rule.id} from {source.ip} to {destination.ip} protocol {network.protocol}",
+      "conditions": [
+        {
+          "field": "stormshield.filter.action",
+          "value": "log"
+        }
+      ],
+      "relationships": [
+        {
+          "source": "source.ip",
+          "target": "destination.ip",
+          "type": "connected to"
+        }
+      ]
     }
   ],
   "apache": [


### PR DESCRIPTION
from Stormshield documentation:
action Behavior associated with the filter rule.
Value: “pass” or “block” (empty field for “Log” action
![Screenshot from 2022-03-17 17-49-07](https://user-images.githubusercontent.com/8960084/158851948-38c7e35c-d885-4301-bb88-eca2512d4dee.png)

