### PR TITLE
feat(Smart Descriptions): First improvement for Azure AD smart descriptions.

### DIFF
--- a/events/smart-descriptions.json
+++ b/events/smart-descriptions.json
@@ -3380,15 +3380,55 @@
       ]
     }
   ],
-  "azure active directory": [{
-      "value": "Azure AD: {action.name} succeeded",
-      "conditions": []
+  "azure active directory": [
+    {
+      "value": "{service.name}: {action.name} from {source.ip}",
+      "conditions": [{
+        "field": "service.name"
+      },
+      {
+        "field": "action.name"
+      },
+      {
+        "field": "source.ip"
+      }
+      ]
     },
     {
-      "value": "Azure AD: {action.name} failed (reason: {action.outcome_reason})",
+      "value": "{service.name} - {azuread.category}: {action.name}",
       "conditions": [{
+        "field": "service.name"
+      },
+      {
+        "field": "action.name"
+      },
+      {
+        "field": "azuread.category"
+      }
+      ]
+    },
+    {
+      "value": "{service.name}: {action.name} failed {action.outcome_reason}",
+      "conditions": [
+        {
         "field": "action.outcome",
         "value": "failure"
+      },
+      {
+        "field": "action.outcome_reason"
+      },
+      {
+        "field": "service.name"
+      },
+      {
+        "field": "action.name"
+      }
+      ]
+    },
+    {
+      "value": "{event.reason}",
+      "conditions": [{
+        "field": "event.reason"
       }]
     }
   ],


### PR DESCRIPTION
The previous Azure AD Smart Description would always say `Azure AD:Sign-in activity
succeeded`.

Can be tested by setting the following cookie via the browser's console:

```kv
document.cookie = "event-smart-descriptions=https://raw.githubusercontent.com/SEKOIA-IO/Community/0aabf471fe9cad52bd2dad569db0b3cfb63557ad/events/smart-descriptions.json"
```