### PR TITLE
PlaybookTemplates: change the way to forward events in AWS playbook templates

### DIFF
--- a/playbooks/templates/forward_aws_cloudtrail_records.json
+++ b/playbooks/templates/forward_aws_cloudtrail_records.json
@@ -21,7 +21,7 @@
         "default": []
       },
       "arguments": {
-        "events": "{{ node.0['records'] }}",
+        "events_path": "{{ node.0['records_path'] }}",
         "intake_key": ""
       },
       "action_uuid": "10314466-ac0c-4067-8e81-4093e3d1e1da",

--- a/playbooks/templates/forward_aws_flowlogs_records.json
+++ b/playbooks/templates/forward_aws_flowlogs_records.json
@@ -21,7 +21,7 @@
         "default": []
       },
       "arguments": {
-        "events": "{{ node.0['records'] }}",
+        "events_path": "{{ node.0['records_path'] }}",
         "intake_key": ""
       },
       "action_uuid": "10314466-ac0c-4067-8e81-4093e3d1e1da",


### PR DESCRIPTION
Forward events through objects instead of supplying events as arguments