### PR TITLE
feat/Enrich_alerts_with_AbuseIPDB

### DIFF
--- a/playbooks/templates/Enrich_alerts_with_AbuseIPDB.json
+++ b/playbooks/templates/Enrich_alerts_with_AbuseIPDB.json
@@ -1,0 +1,87 @@
+{
+  "name": "Enrich alerts with AbuseIPDB",
+  "uuid": "9886ab71-9426-48fb-a2a3-60925fa7f298",
+  "nodes": {
+    "0": {
+      "name": "Manual trigger",
+      "type": "trigger",
+      "outputs": {
+        "default": [
+          "4"
+        ]
+      },
+      "module_uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a",
+      "trigger_uuid": "fc26eb9f-b272-4c15-b3bf-ace397c0dc57"
+    },
+    "1": {
+      "name": "Read for IP",
+      "type": "action",
+      "outputs": {
+        "default": [
+          "6"
+        ]
+      },
+      "arguments": {
+        "file": "{{ node.4.stix }}",
+        "to_file": false,
+        "jsonpath": "$.objects[?(type=\"observed-data\")].objects[?(@.type=\"ipv4-addr\")].value",
+        "return_list": true
+      },
+      "action_uuid": "ecedfa52-7033-4ea8-9c3b-93ad34295f87",
+      "module_uuid": "07cce76b-a319-40ee-a0cf-1ba433431e21"
+    },
+    "4": {
+      "name": "Get alert information",
+      "type": "action",
+      "outputs": {
+        "default": [
+          "1"
+        ]
+      },
+      "arguments": {
+        "stix": true,
+        "uuid": "{{ node.0['alert_uuid'] }}"
+      },
+      "action_uuid": "8d189665-5401-4098-8d60-944de9a6199a",
+      "module_uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a"
+    },
+    "6": {
+      "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCBkPSJNNC41IDExaC0yVjlIMXY2aDEuNXYtMi41aDJWMTVINlY5SDQuNXYyem0yLjUtLjVoMS41VjE1SDEwdi00LjVoMS41VjlIN3YxLjV6bTUuNSAwSDE0VjE1aDEuNXYtNC41SDE3VjloLTQuNXYxLjV6bTktMS41SDE4djZoMS41di0yaDJjLjggMCAxLjUtLjcgMS41LTEuNXYtMWMwLS44LS43LTEuNS0xLjUtMS41em0wIDIuNWgtMnYtMWgydjF6Ii8+PHBhdGggZD0iTTI0IDI0SDBWMGgyNHYyNHoiIGZpbGw9Im5vbmUiLz48L3N2Zz4=",
+      "name": "Request AbuseIPDB",
+      "type": "action",
+      "outputs": {
+        "default": [
+          "7"
+        ]
+      },
+      "arguments": {
+        "url": "https://api.abuseipdb.com/api/v2/check",
+        "method": "get",
+        "params": "{\n    'ipAddress': '{{ node.1['output'][0] }}',\n    'maxAgeInDays': '90'\n}",
+        "headers": {
+          "Key": "2ae93a094934df3e885d5dc5e79c38b46736138c7e83974885f75b8746da1dc72eb19cbf305c1dc8",
+          "Accept": "application/json"
+        }
+      },
+      "action_uuid": "40bcf3c0-aa8b-4111-9b4e-f3caffccb4e5",
+      "module_uuid": "5894985f-91eb-46db-9306-cc5ac6463d3d"
+    },
+    "7": {
+      "icon": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTcwIiBoZWlnaHQ9IjE3MCIgdmlld0JveD0iMCAwIDE3MCAxNzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0zNy4zNjU3IDU3LjgwMzlIMjcuNzE1MVYxMTMuNjg2SDM3LjM2NTdWNTcuODAzOVoiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGQ9Ik05LjY1MDY2IDM3LjY4NjNINTYuNDE5Mkg2Ni4wNjk5SDE2MC4xMDJWMTMyLjA2NUg2Ni4wNjk5SDU2LjQxOTJIOS42NTA2NlYzNy42ODYzWk0wIDE0MkgxNzBWMjhIMFYxNDJaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMTEzLjMzNCA1Ny44MDM5QzEyOC42NzYgNTcuODAzOSAxNDEuMDQ4IDcwLjIyMjIgMTQxLjA0OCA4NS42MjA5QzE0MS4wNDggMTAxLjAyIDEyOC42NzYgMTEzLjQzOCAxMTMuMzM0IDExMy40MzhDOTcuOTkxNiAxMTMuNDM4IDg1LjYxOSAxMDEuMDIgODUuNjE5IDg1LjYyMDlDODUuNjE5IDcwLjIyMjIgOTcuOTkxNiA1Ny44MDM5IDExMy4zMzQgNTcuODAzOVpNMTEzLjMzNCAxMjMuMzczQzEzNC4xMiAxMjMuMzczIDE1MC45NDYgMTA2LjQ4NCAxNTAuOTQ2IDg1LjYyMDlDMTUwLjk0NiA2NC43NTgxIDEzNC4xMiA0OC4xMTc2IDExMy4zMzQgNDguMTE3NkM5Mi41NDc2IDQ4LjExNzYgNzUuNzIwOSA2NS4wMDY1IDc1LjcyMDkgODUuODY5MkM3NS43MjA5IDEwNi43MzIgOTIuNTQ3NiAxMjMuMzczIDExMy4zMzQgMTIzLjM3M1oiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=",
+      "name": "Comment Alert with information from AbuseIPDB",
+      "type": "action",
+      "outputs": {
+        "default": []
+      },
+      "arguments": {
+        "uuid": "{{ node.0['alert_uuid'] }}",
+        "author": "AbuseIPDB Playbook",
+        "content": "AbuseIPDB provides us this information:  \nConfidence of Abuse is {{ node.6['json']['data']['abuseConfidenceScore'] }}%: \n- Isp: \"{{ node.6['json']['data']['isp'] }}\", \n- domain: \"{{ node.6['json']['data']['domain'] }}\", \n- usageType: \"{{ node.6['json']['data']['usageType'] }}\", \n- isWhitelisted: \"{{ node.6['json']['data']['isWhitelisted'] }}\",\n- lastReportedAt: \"{{ node.6['json']['data']['lastReportedAt'] }}\",  \n[Direct link to AbuseIPDB](https://www.abuseipdb.com/check/{{ node.1['output'][0] }}) "
+      },
+      "action_uuid": "0d323de3-a864-4afe-a0c3-e7ff45883d7a",
+      "module_uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a"
+    }
+  },
+  "workspace": "Operation Center",
+  "description": "Enrich with AbuseIPDB to check if the IP is known from this service direclty from SEKOIA.IO."
+}

--- a/playbooks/templates/playbooks.json
+++ b/playbooks/templates/playbooks.json
@@ -179,5 +179,12 @@
         "workspace": ["Operation Center"],
         "description": "This playbook consumes records from Google Pubsub and push them to SEKOIA.IO",
         "tags": ["google", "events"]
+    },
+    {
+        "file": "Enrich_alerts_with_AbuseIPDB.json",
+        "name": "Enrich alerts with AbuseIPDB",
+        "workspace": ["Operation Center"],
+        "description": "Enrich with AbuseIPDB to check if the IP is known from this service, directly from SEKOIA.IO.",
+        "tags": ["alerts", "enrichement"]
     }
 ]


### PR DESCRIPTION
Hello SEKOIA

A new playbook to this fabulous catalog.
This one, is created to use AbuseIPDB API, and provide information directly in the SEKOIA.IO alert when analysts need it.

Some correction since my last PR
~~IPAbuse~~ -> AbuseIPDB
Nodes names are more human-readable now.
Direct link to AbuseIPDB.
Better highlight of AbuseIPDB Confidence of abuse score


Sorry for this PR duplicate.
Best regards