### PR TITLE
Fix/PlaybookVT/Get_IP_andTrigger

### DIFF
--- a/playbooks/templates/VirusTotal_Enrichement.json
+++ b/playbooks/templates/VirusTotal_Enrichement.json
@@ -588,5 +588,5 @@
     }
   },
   "workspace": "Operation Center",
-  "description": "Enhance network alerts with information from Virus Total"
+  "description": "Enrich network alerts with information from Virus Total"
 }


### PR DESCRIPTION
Hello SEKOIA.IO

I am coming back to your best playbook: Enhance network alerts with VirusTotal.

Several changes.
Change to "Created alert" trigger and not Security trigger.
Using GET Event, to have the right destination.ip to avoid any confusion with some STIX badly formatted.