### PR TITLE
Add Okta Integration

### DIFF
--- a/playbooks/templates/forward_okta_logs.json
+++ b/playbooks/templates/forward_okta_logs.json
@@ -1,0 +1,124 @@
+{
+    "name": "Okta logs importer",
+    "nodes": {
+      "1": {
+        "name": "Store",
+        "type": "operator",
+        "outputs": {
+          "default": [
+            "2"
+          ]
+        },
+        "subtype": "store",
+        "modifications": [
+          {
+            "key": "start",
+            "type": "set",
+            "value": "{{ (-120) | time_with_delta}}"
+          },
+          {
+            "key": "end",
+            "type": "set",
+            "value": "{{ (-60) | time_with_delta }}"
+          }
+        ]
+      },
+      "2": {
+        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCBkPSJNNC41IDExaC0yVjlIMXY2aDEuNXYtMi41aDJWMTVINlY5SDQuNXYyem0yLjUtLjVoMS41VjE1SDEwdi00LjVoMS41VjlIN3YxLjV6bTUuNSAwSDE0VjE1aDEuNXYtNC41SDE3VjloLTQuNXYxLjV6bTktMS41SDE4djZoMS41di0yaDJjLjggMCAxLjUtLjcgMS41LTEuNXYtMWMwLS44LS43LTEuNS0xLjUtMS41em0wIDIuNWgtMnYtMWgydjF6Ii8+PHBhdGggZD0iTTI0IDI0SDBWMGgyNHYyNHoiIGZpbGw9Im5vbmUiLz48L3N2Zz4=",
+        "name": "Request URL",
+        "type": "action",
+        "outputs": {
+          "default": [
+            "4"
+          ]
+        },
+        "arguments": {
+          "url": "https://ENDPOINT.okta.com/api/v1/logs",
+          "method": "get",
+          "params": "since={{ store.start | urlencode }}&until={{ store.end | urlencode }}&sortOrder=ASCENDING",
+          "headers": {
+            "Authorization": "SSWS APIKEY"
+          }
+        },
+        "action_uuid": "40bcf3c0-aa8b-4111-9b4e-f3caffccb4e5",
+        "module_uuid": "5894985f-91eb-46db-9306-cc5ac6463d3d"
+      },
+      "3": {
+        "name": "cron",
+        "type": "trigger",
+        "outputs": {
+          "default": [
+            "1"
+          ]
+        },
+        "module_uuid": "1ad1b7ce-e335-4532-83ce-1d43c864720c",
+        "trigger_uuid": "5039c9fe-b2d8-40b3-a11b-d2a810ddbf91"
+      },
+      "4": {
+        "loop": [
+          "6"
+        ],
+        "name": "Foreach",
+        "type": "operator",
+        "items": "{{ node.2['json'] }}",
+        "outputs": {
+          "default": []
+        },
+        "subtype": "foreach"
+      },
+      "5": {
+        "icon": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTcwIiBoZWlnaHQ9IjE3MCIgdmlld0JveD0iMCAwIDE3MCAxNzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0zNy4zNjU3IDU3LjgwMzlIMjcuNzE1MVYxMTMuNjg2SDM3LjM2NTdWNTcuODAzOVoiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGQ9Ik05LjY1MDY2IDM3LjY4NjNINTYuNDE5Mkg2Ni4wNjk5SDE2MC4xMDJWMTMyLjA2NUg2Ni4wNjk5SDU2LjQxOTJIOS42NTA2NlYzNy42ODYzWk0wIDE0MkgxNzBWMjhIMFYxNDJaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMTEzLjMzNCA1Ny44MDM5QzEyOC42NzYgNTcuODAzOSAxNDEuMDQ4IDcwLjIyMjIgMTQxLjA0OCA4NS42MjA5QzE0MS4wNDggMTAxLjAyIDEyOC42NzYgMTEzLjQzOCAxMTMuMzM0IDExMy40MzhDOTcuOTkxNiAxMTMuNDM4IDg1LjYxOSAxMDEuMDIgODUuNjE5IDg1LjYyMDlDODUuNjE5IDcwLjIyMjIgOTcuOTkxNiA1Ny44MDM5IDExMy4zMzQgNTcuODAzOVpNMTEzLjMzNCAxMjMuMzczQzEzNC4xMiAxMjMuMzczIDE1MC45NDYgMTA2LjQ4NCAxNTAuOTQ2IDg1LjYyMDlDMTUwLjk0NiA2NC43NTgxIDEzNC4xMiA0OC4xMTc2IDExMy4zMzQgNDguMTE3NkM5Mi41NDc2IDQ4LjExNzYgNzUuNzIwOSA2NS4wMDY1IDc1LjcyMDkgODUuODY5MkM3NS43MjA5IDEwNi43MzIgOTIuNTQ3NiAxMjMuMzczIDExMy4zMzQgMTIzLjM3M1oiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=",
+        "name": "Push Events to Intake",
+        "type": "action",
+        "outputs": {
+          "default": []
+        },
+        "arguments": {
+          "event": "{{ node.4.default.value }}",
+          "intake_key": "",
+          "intake_server": "",
+          "keep_file_after_push": false
+        },
+        "action_uuid": "10314466-ac0c-4067-8e81-4093e3d1e1da",
+        "module_uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a"
+      },
+      "6": {
+        "icon": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTcwIiBoZWlnaHQ9IjE3MCIgdmlld0JveD0iMCAwIDE3MCAxNzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik0zNy4zNjU3IDU3LjgwMzlIMjcuNzE1MVYxMTMuNjg2SDM3LjM2NTdWNTcuODAzOVoiIGZpbGw9ImJsYWNrIi8+CjxwYXRoIGQ9Ik05LjY1MDY2IDM3LjY4NjNINTYuNDE5Mkg2Ni4wNjk5SDE2MC4xMDJWMTMyLjA2NUg2Ni4wNjk5SDU2LjQxOTJIOS42NTA2NlYzNy42ODYzWk0wIDE0MkgxNzBWMjhIMFYxNDJaIiBmaWxsPSJibGFjayIvPgo8cGF0aCBkPSJNMTEzLjMzNCA1Ny44MDM5QzEyOC42NzYgNTcuODAzOSAxNDEuMDQ4IDcwLjIyMjIgMTQxLjA0OCA4NS42MjA5QzE0MS4wNDggMTAxLjAyIDEyOC42NzYgMTEzLjQzOCAxMTMuMzM0IDExMy40MzhDOTcuOTkxNiAxMTMuNDM4IDg1LjYxOSAxMDEuMDIgODUuNjE5IDg1LjYyMDlDODUuNjE5IDcwLjIyMjIgOTcuOTkxNiA1Ny44MDM5IDExMy4zMzQgNTcuODAzOVpNMTEzLjMzNCAxMjMuMzczQzEzNC4xMiAxMjMuMzczIDE1MC45NDYgMTA2LjQ4NCAxNTAuOTQ2IDg1LjYyMDlDMTUwLjk0NiA2NC43NTgxIDEzNC4xMiA0OC4xMTc2IDExMy4zMzQgNDguMTE3NkM5Mi41NDc2IDQ4LjExNzYgNzUuNzIwOSA2NS4wMDY1IDc1LjcyMDkgODUuODY5MkM3NS43MjA5IDEwNi43MzIgOTIuNTQ3NiAxMjMuMzczIDExMy4zMzQgMTIzLjM3M1oiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=",
+        "name": "Get Events",
+        "type": "action",
+        "outputs": {
+          "default": [
+            "7"
+          ]
+        },
+        "arguments": {
+          "query": "event.dialect: \"okta\" AND okta.uuid: \"{{ node.4.default.value.uuid }}\" ",
+          "latest_time": "{{store.end}}",
+          "earliest_time": "{{store.start}}"
+        },
+        "action_uuid": "af0b4355-a428-43d6-991c-d5ff878e17d5",
+        "module_uuid": "92d8bb47-7c51-445d-81de-ae04edbb6f0a"
+      },
+      "7": {
+        "name": "Condition",
+        "type": "operator",
+        "cases": [
+          {
+            "left": "{{ node.6['events']|length }}",
+            "name": "Events already present",
+            "right": "{{ 1 }}",
+            "comparison": ">="
+          }
+        ],
+        "outputs": {
+          "else": [
+            "5"
+          ],
+          "Events already present": []
+        },
+        "subtype": "condition"
+      }
+    },
+    "workspace": "Operation Center",
+    "description": "This playbook collect events from Okta and push them to SEKOIA.IO"
+  }


### PR DESCRIPTION
Hello,

Add [Okta](https://www.okta.com/) playbook integration.

Currently, there is one limitation : handling pagination.

Okta send the paginator with an already used header, and can use twice the same header in the same response.
Currently I didn't find any real solution for this issue.

https://developer.okta.com/docs/reference/core-okta-api/#pagination

Need a custom intake (will push it soon)